### PR TITLE
Add `no-arguments` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2018"
 
 [lib]
 proc-macro = true
+
+[features]
+no-arguments = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 extern crate proc_macro;
 
+#[allow(unused_variables)]
 #[proc_macro_attribute]
-pub fn noop(_: proc_macro::TokenStream, body: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn noop(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    #[cfg(feature = "no-arguments")]
+    assert!(attr.is_empty(), "this attribute takes no arguments");
     body
 }


### PR DESCRIPTION
Would you consider adding a feature to require that no arguments be passed to the attribute?

I imagine this would be useful in a large number of cases.